### PR TITLE
Remove `traverse` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "spawn-error-forwarder": "~1.0.0",
     "split2": "~1.0.0",
     "stream-combiner2": "~1.1.1",
-    "through2": "~2.0.0",
-    "traverse": "~0.6.6"
+    "through2": "~2.0.0"
   },
   "devDependencies": {
     "chai": "~1.10.0",

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@
 var spawn    = require('child_process').spawn;
 var through  = require('through2');
 var split    = require('split2');
-var traverse = require('traverse');
 var fields   = require('./fields');
 var toArgv   = require('argv-formatter').format;
 var combine  = require('stream-combiner2');
@@ -42,6 +41,19 @@ function args (config, fieldMap) {
   return toArgv(config);
 }
 
+function setByPath(obj, path, value) {
+  var dest = obj;
+  for (var i = 0; i < path.length - 1; i++) {
+    var key = path[i];
+    if (!Object.prototype.hasOwnProperty.call(obj, key)) {
+      obj[key] = {};
+    }
+    dest = dest[key];
+  }
+
+  dest[path[path.length - 1]] = value;
+}
+
 exports.parse = function parseLogStream (config, options) {
   config  = config || {};
   var map = fields.map();
@@ -53,7 +65,7 @@ exports.parse = function parseLogStream (config, options) {
       var fields = chunk.toString('utf8').split(FIELD);
       callback(null, map.reduce(function (parsed, field, index) {
         var value = fields[index];
-        traverse(parsed).set(field.path, field.type ? new field.type(value) : value);
+        setByPath(parsed, field.path, field.type ? new field.type(value) : value);
         return parsed;
       }, {}));
     })


### PR DESCRIPTION
This dependency pulls in over 50 transitive dependencies, totaling 16 MB from npm. Let's just reimplement the relevant logic ourselves.

I've tested this down to Node 0.10, the oldest version that runs on my machine.