### PR TITLE
Pin `traverse` to v0.6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "split2": "~1.0.0",
     "stream-combiner2": "~1.1.1",
     "through2": "~2.0.0",
-    "traverse": "~0.6.6"
+    "traverse": "0.6.8"
   },
   "devDependencies": {
     "chai": "~1.10.0",


### PR DESCRIPTION
An alternative to #7.

This pins the `traverse` dependency to v0.6.8 exactly, which is the last version with 0 dependencies.

v0.6.9 added [over 50 transitive dependencies](https://npmgraph.js.org/?q=traverse).

Closes #7 